### PR TITLE
Run tests on Linux in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!mypy.ini
+!setup.cfg
+!setup.py
+!strainmap
+!tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 *.pyc
 
-**/htmlcov/
-**/junit/
+/reports/
 **/.coverage
-**/coverage.xml
 /StrainMap.egg-info/
 /pip-wheel-metadata/
 /.eggs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-slim AS strainmap
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends python3-tk \
+    && rm -fr /var/lib/apt/lists/*
+WORKDIR /usr/src/app
+COPY setup.py .
+COPY strainmap ./strainmap
+RUN python -mpip install -e .
+
+FROM strainmap
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends xvfb xauth \
+    && rm -fr /var/lib/apt/lists/*
+COPY . .
+ENTRYPOINT xvfb-run -a python setup.py -q test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,9 @@
 strategy:
   matrix:
-    windows:
-      imageName: windows-2019
-      pythonVersion: 3.7
     linux:
       imageName: ubuntu-16.04
+    windows:
+      imageName: windows-2019
       pythonVersion: 3.7
     umac:
       imageName: macos-10.13
@@ -14,40 +13,31 @@ pool:
   vmImage: $(imageName)
 
 steps:
+  - script: |
+      docker build -t strainmap-test .
+      docker run --rm -v $(pwd)/reports:/usr/src/app/reports strainmap-test
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: "Run tests in Linux"
+
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(pythonVersion)
-      architecture: "x64"
-
-  - script: |
-      sudo apt update
-      sudo apt install python3-tk xvfb
-    displayName: "Install system dependencies in Linux"
-    condition: eq(variables['Agent.OS'], 'Linux')
+    condition: ne(variables['Agent.OS'], 'Linux')
 
   - script: |
       pip install -e .
-    displayName: "Install prerequisites"
-
-  - script: |
-      xvfb-run -a python setup.py -q test
-    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
-    displayName: "Run tests in Linux"
-    enabled: false
-
-  - script: |
       python setup.py -q test
-    condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))
-    displayName: "Run tests in Windows or MacOS"
+    condition: ne(variables['Agent.OS'], 'Linux')
+    displayName: "Run tests in Windows and macOS"
 
   - task: PublishTestResults@2
     inputs:
-      testResultsFiles: "**/test-*.xml"
+      testResultsFiles: "**/junit.xml"
     condition: succeededOrFailed()
 
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: "**/coverage.xml"
-      reportDirectory: "**/htmlcov"
+      reportDirectory: "**/coverage"
     condition: succeededOrFailed()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 test=pytest
 [tool:pytest]
 addopts =
-    --flake8 --mypy --junitxml=junit/test-results.xml
-    --cov=strainmap --cov-report=xml --cov-report=html
+    --flake8 --mypy --junitxml=reports/junit.xml
+    --cov=strainmap --cov-report=xml:reports/coverage.xml --cov-report=html:reports/coverage
     --doctest-modules --ignore=examples
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Avoids issues with: hosted Python install no longer being built with tk; system Python being 3.5; container environment not having sudo installed and therefore it not being possible to install either python3-tk or an alternative version of Python.