### PR TITLE
Calculates pixel position (in units of length) in cylindrical coordinates.

### DIFF
--- a/strainmap/models/strain.py
+++ b/strainmap/models/strain.py
@@ -1,0 +1,63 @@
+import numpy as np
+from typing import Tuple, Union
+
+
+def cartcoords(
+    shape: tuple, zsize: Union[float, np.ndarray], xsize: float, ysize: float
+) -> Tuple:
+    """Create cartesian coordinates of the given shape based on the pixel sizes.
+
+    As slices can be separated by a different number, zsize can also be an array of
+    positions in the Z direction rather than an scalar.
+    """
+    if isinstance(zsize, np.ndarray):
+        z = zsize - zsize[0]
+    else:
+        z = np.linspace(0, zsize, shape[0])
+    x = np.linspace(0, xsize, shape[1])
+    y = np.linspace(0, ysize, shape[2])
+
+    return z, x, y
+
+
+def cylcoords(
+    z: np.ndarray,
+    x: np.ndarray,
+    y: np.ndarray,
+    origin: np.ndarray,
+    theta0: Union[float, np.ndarray],
+) -> Tuple:
+    """Calculate the cylindrical coordinates out of X, Y Z, an origin and theta0."""
+
+    org = validate_origin(origin, len(z))
+    th0 = validate_theta0(theta0, len(z))
+
+    zz, xx, yy = np.meshgrid(z, x, y, indexing="ij")
+    xx -= org[:, -2:-1, None]
+    yy -= org[:, -1:, None]
+    r = np.sqrt(xx ** 2 + yy ** 2)
+    theta = np.arctan2(yy, xx) - th0[:, None, None]
+    return zz, r, theta
+
+
+def validate_origin(origin: np.ndarray, lenz: int):
+    """Validates the shape of the origin array."""
+
+    msg = "Origin must be a 1D array of length 2 or a 2D array of shape (len(z), 2)"
+    if len(origin.shape) == 1:
+        assert len(origin) == 2, msg
+        return np.tile(origin, (lenz, 1))
+    elif len(origin.shape) == 2:
+        assert origin.shape == (lenz, 2), msg
+        return origin
+    else:
+        raise ValueError(msg)
+
+
+def validate_theta0(theta0: Union[float, np.ndarray], lenz: int):
+    """Validates the shape of the theta0 array."""
+    if isinstance(theta0, np.ndarray):
+        assert theta0.shape == (lenz,), f"If an array, theta0 must have shape {(lenz,)}"
+        return theta0
+    else:
+        return np.array([theta0] * lenz)

--- a/tests/test_strain.py
+++ b/tests/test_strain.py
@@ -1,0 +1,70 @@
+from pytest import approx, raises
+
+
+def test_cartcoords():
+    from strainmap.models.strain import cartcoords
+    import numpy as np
+
+    shape = tuple(np.random.randint(2, 6, 3))
+    size = np.random.rand(3) * 10
+    expected = cartcoords(shape, *size)
+    for i, v in enumerate(expected):
+        assert len(v) == shape[i]
+        assert max(v) == size[i]
+
+    zsize = np.random.rand(shape[0])
+    expected = cartcoords(shape, zsize, size[1], size[2])
+    assert len(expected[0]) == len(zsize) == shape[0]
+    assert expected[0] == approx(zsize - zsize[0])
+
+
+def test_cylcoords():
+    from strainmap.models.strain import cylcoords, cartcoords
+    import numpy as np
+
+    shape = tuple(np.random.randint(2, 6, 3))
+    size = np.random.rand(3) * 10
+    z, x, y = cartcoords(shape, *size)
+    origin = np.array([x.mean(), y.mean()])
+    theta0 = np.random.rand() * np.pi * 2
+
+    zz, r, theta = cylcoords(z, x, y, origin, theta0)
+    assert zz - z[:, None, None] == approx(np.zeros_like(zz))
+    assert r * np.cos(theta + theta0) + origin[-2] == approx(
+        np.tile(x, (shape[0], shape[2], 1)).transpose((0, 2, 1))
+    )
+    assert r * np.sin(theta + theta0) + origin[-1] == approx(
+        np.tile(y, (shape[0], shape[1], 1))
+    )
+
+
+def test_validate_origin():
+    from strainmap.models.strain import validate_origin
+    import numpy as np
+
+    origin = np.random.rand(2)
+    lenz = np.random.randint(10)
+    expected = np.tile(origin, (lenz, 1))
+
+    assert validate_origin(origin, lenz) == approx(expected)
+    assert validate_origin(expected, lenz) == approx(expected)
+    with raises(AssertionError):
+        validate_origin(origin[1:], lenz)
+    with raises(AssertionError):
+        validate_origin(expected, 100)
+    with raises(ValueError):
+        validate_origin(np.zeros((1, 1, 1)), lenz)
+
+
+def test_validate_theta0():
+    from strainmap.models.strain import validate_theta0
+    import numpy as np
+
+    theta0 = np.random.rand()
+    lenz = np.random.randint(10)
+    expected = np.array([theta0] * lenz)
+
+    assert validate_theta0(theta0, lenz) == approx(expected)
+    assert validate_theta0(expected, lenz) == approx(expected)
+    with raises(AssertionError):
+        validate_theta0(expected, 100)


### PR DESCRIPTION
The calculation is done based on pixel indices, pixel size and slice separation/position. 

The support for long axis slices is not included, for now, as these come already in cylindrical coordinates and it is unclear how they can be mixed and matched with short axis slices. Support for that will be added when/if needed. 

Close #81 .

EDIT: The functions added here, and others I'm working on now, might be better suited included in `contour_mask.py`, but I think we need to re-organise and rename a couple of modules, so let's keep them separated for now, until they are all working as they should. 