### PR TITLE
Use version of setuptools that includes fix for pypa/setuptools#1963

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email="rcs-support@imperial.ac.uk",
     setup_requires=["pytest-runner"],
     install_requires=[
+        "setuptools>=49.1.1",
         "pillow",
         "pydicom",
         "scikit-image<=0.15",


### PR DESCRIPTION
Use version of setuptools that includes fix for pypa/setuptools#1963

Fixes #117

