### PR TITLE
Use epicardium only to calculate COM

### DIFF
--- a/strainmap/gui/segmentation_view.py
+++ b/strainmap/gui/segmentation_view.py
@@ -31,7 +31,7 @@ from .figure_actions_manager import (
     MouseAction,
     Location,
 )
-from ..models.contour_mask import contour_diff
+from ..models.contour_mask import Contour
 
 
 @register_view
@@ -432,11 +432,10 @@ class SegmentationTaskView(TaskViewBase):
     @property
     def centroid(self):
         """Return an array with the position of the centroid at a given time."""
-        mask = contour_diff(
+        mask = Contour(
             self.final_segments["epicardium"][self.current_frame].T,
-            self.final_segments["endocardium"][self.current_frame].T,
             shape=self.images["mag"][self.current_frame].shape,
-        )
+        ).mask
         return np.array(ndimage.measurements.center_of_mass(mask))
 
     @property

--- a/strainmap/models/quick_segmentation.py
+++ b/strainmap/models/quick_segmentation.py
@@ -1,6 +1,6 @@
 from .segmenters import Segmenter
 from .strainmap_data_model import StrainMapData
-from .contour_mask import Contour, dilate, contour_diff
+from .contour_mask import Contour, dilate
 
 import numpy as np
 from scipy import ndimage
@@ -113,12 +113,8 @@ def centroid(segments, frame, shape):
     """Return an array with the position of the centroid at a given time."""
     mask = np.array(
         [
-            ndimage.measurements.center_of_mass(
-                contour_diff(outer.T, inner.T, shape=shape)
-            )
-            for outer, inner in zip(
-                segments["epicardium"][frame], segments["endocardium"][frame]
-            )
+            ndimage.measurements.center_of_mass(Contour(outer.T, shape=shape).mask)
+            for outer in segments["epicardium"][frame]
         ]
     )
     return mask


### PR DESCRIPTION
To calculate the center of mass - or centroid - only the epicardium information should be use.